### PR TITLE
Constraint UnboundTypeProvider and UnboundClassProvider.useClass to classes with no-args constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,19 +100,22 @@ The type parameter `T` is the type of value that will be resolved by the provide
 Under the hood, the `UnboundProvider<T>` type, is simply the union of the following types:
 
 * `UnboundTypeProvider` - Uses the specified class to instantiate a value for injection.
+  The class must have a no-args constructor.
   The instance will be reused for subsequent usages of the same class as `UnboundTypeProvider`.
   In addition the class itself will also be made available as token for injection.
 
-  **Model Definition:** `UnboundTypeProvider<T> = Type<T>`
+  **Model Definition:** `UnboundTypeProvider<T> = Type<T> & HasNoArgsConstructor`
 
 * `UnboundValueProvider` - Uses the value of the `useValue` field for injection.
 
   **Model Definition:** `UnboundValueProvider<T> { useValue: T }`
 
 * `UnboundClassProvider` - Creates an instance of the specified class as injection value.
+  The class must have a no-args constructor.
+  `useClass` with `deps` is not supported. If you wish to use a class with constructor arguments, use `UnboundFactoryProvider` (`useFactory`) instead.
   Note that unlike `UnboundTypeProvider` multiple uses of the same class as `UnboundClassProvider` will also result in multiple instances of that class.
 
-  **Model Definition:** `UnboundClassProvider<T> { useClass: Type<T>;}`
+  **Model Definition:** `UnboundClassProvider<T> { useClass: Type<T> & HasNoArgsConstructor }`
 
 * `UnboundExistingProvider` - Reuses another provider, which is referenced using the specified token, to resolve the value that will be used for injection.
 

--- a/lib/src/provider-binding.ts
+++ b/lib/src/provider-binding.ts
@@ -2,8 +2,10 @@ import { Provider, Type } from '@angular/core';
 
 import { Token } from './token.model';
 
+export type HasNoArgsConstructor = new () => unknown;
+
 /** Definition (without token binding) for providers that will create a singleton instance of the specified class for injection. */
-export type UnboundTypeProvider<T> = Type<T>;
+export type UnboundTypeProvider<T> = Type<T> & HasNoArgsConstructor;
 
 /** Definition (without token binding) for providers that use the specified value for injection. */
 export interface UnboundValueProvider<T> {
@@ -14,7 +16,7 @@ export interface UnboundValueProvider<T> {
 /** Definition (without token binding) for providers that instantiate a specific class for injection. */
 export interface UnboundClassProvider<T> {
     /** Class to instantiate when being injected for a specific token. */
-    useClass: Type<T>;
+    useClass: Type<T> & HasNoArgsConstructor;
 }
 
 /** Definition (without token binding) for providers that reference another token to use for injection. */


### PR DESCRIPTION
After extensive testing, I discovered that when passing a class with constructor arguments as a `Type` or `useClass` in a provider, Angular will not automatically resolve the dependencies, even if the constructor arguments are annotated with the `@Inject` decorator.

To prevent such mistakes, we should limit `UnboundTypeProvider` and `UnboundClassProvider.useClass` to only classes with a no-args constructor.

To provide a class with constructor arguments in Angular, normally we will need to use `useClass` and `deps` (see https://github.com/angular/angular/blob/13.0.0/packages/core/src/di/injectable.ts#L19-L25 and https://github.com/angular/angular/blob/13.0.0/packages/core/src/di/interface/provider.ts#L53-L71). However, `UnboundClassProvider` does not support `deps`.

I don't think adding support for `useClass` and `deps` is a good idea, especially if we want to constraint the type of `deps` to the constructor args provider tokens (as I did with `useFactory` in #35), for 2 reasons:
- it would be extremely difficult to type `deps` conditionally depending on whether `useFactory` or `useClass` is specified
- the same can be achieved using `useFactory`, e.g.
instead of:
```ts
{
  useClass: MyClass,
  deps: [SomeDependency],
}
```
the same can be achieved with:
```ts
{
  useFactory: (someDependency: SomeDependency) => new MyClass(someDependency),
  deps: [SomeDependency],
}
```